### PR TITLE
Add option for error limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,37 @@ npm install -g hpt-validator-cli
 
 ```sh
 cms-hpt-validator --help
-Usage: cms-hpt-validator [options] <filepath> <version>
+Usage: index [options] <filepath> <version>
 
 Arguments:
-  filepath               filepath to validate
-  version                (choices: "v1.1")
+  filepath                   filepath to validate
+  version                    (choices: "v2.0", "v2.0.0")
 
 Options:
-  -f, --format <string>  file format of file (choices: "csv", "json")
-  -h, --help             display help for command
+  -f, --format <string>      file format of file (choices: "csv", "json")
+  -e, --error-limit <value>  maximum number for errors and warnings (default:
+                             1000)
+  -h, --help                 display help for command
 ```
 
-### Example
+### Examples
+
+Basic usage:
 
 ```sh
-cms-hpt-validator ./sample.csv
+cms-hpt-validator ./sample.csv v2.0.0
+```
+
+Overriding the default error limit to show 50 errors and warnings:
+
+```sh
+cms-hpt-validator ./sample.csv v2.0.0 -e 50
+```
+
+Overriding the default error limit to show all errors and warnings:
+
+```sh
+cms-hpt-validator ./sample.csv v2.0.0 -e 0
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# Hospital Price Transparency Validator CLI
+# Hospital Price Transparency CLI Validator
 
 CLI for validating CMS Hospital Price Transparency machine-readable files
 
 ## Getting Started
+
+### Prerequisites
+These were the minimum versions used to develop the CLI tool. It is recommended to keep both Node and NPM up-to-date with the latest releases.
+
+* Node (version 16.x)  
+* NPM (version 8.5.x)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Overriding the default error limit to show all errors and warnings:
 cms-hpt-validator ./sample.csv v2.0.0 -e 0
 ```
 
+## Limitations
+There may be a situation in which the CLI tool will run out of memory due to the amount of errors that are found in the file being validated. If you run into this NODE error, update the amount of errors to a smaller value that will be allowed to be collected with the `-e, --error-limit` flag.
+
+
 ## Contributing
 
 Thank you for considering contributing to an Open Source project of the US

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { program, Argument, Option } from "commander"
+import { program, Argument, Option, InvalidArgumentError } from "commander"
 import { validate } from "./commands.js"
 
 main().catch((error) => {
@@ -17,7 +17,21 @@ async function main() {
         "json",
       ])
     )
+    .option(
+      "-e, --error-limit <value>",
+      "maximum number for errors and warnings",
+      ensureInt,
+      1000
+    )
     .action(validate)
 
   program.parseAsync(process.argv)
+}
+
+function ensureInt(value: string) {
+  const parsedValue = parseInt(value, 10)
+  if (isNaN(parsedValue)) {
+    throw new InvalidArgumentError("Must be a number.")
+  }
+  return parsedValue
 }


### PR DESCRIPTION
Default error limit is 1000. Having an error limit helps avoid cases where the user's system runs out of memory.

The error limit must be a number. Limits of 0 or less are treated by the validator core as unlimited.