### PR TITLE
Use validator 1.6.2 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "hpt-validator-cli",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator-cli",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "CC0-1.0",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^10.0.1",
-        "hpt-validator": "1.6.1"
+        "hpt-validator": "1.6.2"
       },
       "bin": {
         "cms-hpt-validator": "dist/index.js"
@@ -1193,10 +1193,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.6.1.tgz",
-      "integrity": "sha512-d8CF3M7e7dsX42p296dV/Xy12PF4vGlp2DhmQiux3RXEsSHkIeqP/ce9gTvHb98GD2V9nkfjL/psVuroAVvT5w==",
-      "license": "CC0-1.0",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.6.2.tgz",
+      "integrity": "sha512-JIGcQW1xsnKJccwBM8v/zjWcnb8DTfcjntoVJBnmwaJMnLDBue0Jf7ayXaDlOVo2Wj4le4uLQVYUl6rsumeCIw==",
       "dependencies": {
         "@streamparser/json": "^0.0.17",
         "@types/node": "^20.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator-cli",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "CLI for validating CMS Hospital Price Transparency machine-readable files",
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^10.0.1",
-    "hpt-validator": "1.6.1"
+    "hpt-validator": "1.6.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",


### PR DESCRIPTION
See https://github.com/CMSgov/hpt-validator/releases/tag/v1.6.2 for changes present in new version of `hpt-validator` package.