### PR TITLE
Update validator core to v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "hpt-validator-cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator-cli",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "CC0-1.0",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^10.0.1",
-        "hpt-validator": "1.7.0"
+        "hpt-validator": "1.7.1"
       },
       "bin": {
         "cms-hpt-validator": "dist/index.js"
@@ -1193,9 +1193,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.7.0.tgz",
-      "integrity": "sha512-6sycU1PJuFdi6c3ILox6XOoG24kHCfzbMpKr/gUXPH/rZyPqQKLAwE8e5+0OOOa5fiKTjNlfeUnsHUg7lWbvtw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.7.1.tgz",
+      "integrity": "sha512-bsIPMqZdCO4gAUJ81cNsw4krnMX0mTz22qujvtv86kHbNandWEYKnzAV7+D6C24igs9F+ULrB8W05m1aZ5ZYhg==",
       "dependencies": {
         "@streamparser/json": "^0.0.17",
         "@types/node": "^20.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator-cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "CLI for validating CMS Hospital Price Transparency machine-readable files",
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^10.0.1",
-    "hpt-validator": "1.7.0"
+    "hpt-validator": "1.7.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",


### PR DESCRIPTION
For information about the changes this includes, see [release notes for v1.7.1](https://github.com/CMSgov/hpt-validator/releases/tag/v1.7.1).