### PR TITLE
Support reading from gzipped files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ async function main() {
     .addOption(
       new Option("-f, --format <string>", "file format of file").choices([
         "csv",
+        "csv.gz",
         "json",
+        "json.gz",
       ])
     )
     .option(


### PR DESCRIPTION
Thanks for publishing and maintaining this project. Super helpful stuff!
Feel free to just close this PR if you don't want it. No biggie either way :)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- eslint and prettier should be run against all files and will be checked by CI.

-->

## One line description of your change (less than 72 characters)
Support reading from `.csv.gz` and `.json.gz` files.

## Problem

Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of being the motivation for your change.

I'm compressing the data files locally and need to unzip them before I can run the `hpt-validator-cli`. This just lets us read gzipped files directly.

## Solution

Describe the modifications you've done.

Allow reading directly from gzipped data files.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with
clear instructions on how you verified your changes work.)

Create a gzipped data file 
`$gzip my_file.json`
You should now have a file named `my_file.json.gz`
Run `hpt-validator-cli` on that new file.
Ensure the results are the same as they were on the unzipped file.
