### PR TITLE
Close stream after validation to avoid exhausting memory

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,14 +24,16 @@ export async function validate(
     )
   }
 
+  const inputStream = fs.createReadStream(filepath, "utf-8")
   const validationResult = await validateFile(
-    filepath,
+    inputStream,
     version,
     format as FileFormat,
     {
       maxErrors: options.errorLimit as number,
     }
   )
+  inputStream.close()
   if (!validationResult) return
 
   const errors = validationResult.errors.filter(({ warning }) => !warning)
@@ -62,7 +64,7 @@ export async function validate(
 }
 
 async function validateFile(
-  filename: string,
+  inputStream: fs.ReadStream,
   version: string,
   format: FileFormat,
   validatorOptions: CsvValidationOptions | JsonValidatorOptions
@@ -70,13 +72,13 @@ async function validateFile(
   const schemaVersion = version as "v1.1" | "v2.0"
   if (format === "csv") {
     return await validateCsv(
-      fs.createReadStream(filename, "utf-8"),
+      inputStream,
       schemaVersion,
       validatorOptions as CsvValidationOptions
     )
   } else if (format === "json") {
     return await validateJson(
-      fs.createReadStream(filename, "utf-8"),
+      inputStream,
       schemaVersion,
       validatorOptions as JsonValidatorOptions
     )


### PR DESCRIPTION
## Close stream after validation to avoid exhausting memory

## Problem

When parsing a large CSV that had errors in header rows, the file stream would remain open after the parser had closed. This could cause node to exhaust available heap memory.

## Solution

Close the stream after the validation function returns.

## Result

Node no longer runs out of heap memory when validating the large CSV file.

## Test Plan

Test using CSV MRF that is sufficiently large: the original problem file was 7.3gb, to give a sense of the size to aim for. Before the change, this caused a memory error to occur after validation completed, but before the CLI exited. After the change, no memory error occurred. You may need a different file size based on your local node memory configuration.