### PR TITLE
Remove warnings from output and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Arguments:
 
 Options:
   -f, --format <string>      file format of file (choices: "csv", "json")
-  -e, --error-limit <value>  maximum number for errors and warnings (default:
-                             1000)
+  -e, --error-limit <value>  maximum number for errors (default: 1000)
   -h, --help                 display help for command
 ```
 
@@ -43,13 +42,13 @@ Basic usage:
 cms-hpt-validator ./sample.csv v2.0.0
 ```
 
-Overriding the default error limit to show 50 errors and warnings:
+Overriding the default error limit to show 50 errors:
 
 ```sh
 cms-hpt-validator ./sample.csv v2.0.0 -e 50
 ```
 
-Overriding the default error limit to show all errors and warnings:
+Overriding the default error limit to show all errors:
 
 ```sh
 cms-hpt-validator ./sample.csv v2.0.0 -e 0

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -43,8 +43,7 @@ export async function validate(
   inputStream.close()
   if (!validationResult) return
 
-  const errors = validationResult.errors.filter(({ warning }) => !warning)
-  const warnings = validationResult.errors.filter(({ warning }) => warning)
+  const errors = validationResult.errors
 
   if (errors.length > 0) {
     console.log(
@@ -55,18 +54,6 @@ export async function validate(
     console.table(errors)
   } else {
     console.log(chalk.green("No errors found"))
-  }
-  if (warnings.length > 0) {
-    console.log(
-      chalk.yellow(
-        `${
-          warnings.length === 1 ? "1 warning" : `${warnings.length} warnings`
-        } found`
-      )
-    )
-    console.table(warnings)
-  } else {
-    console.log(chalk.green("No warnings found"))
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ async function main() {
     )
     .option(
       "-e, --error-limit <value>",
-      "maximum number for errors and warnings",
+      "maximum number for errors",
       ensureInt,
       1000
     )


### PR DESCRIPTION
As of January 1, 2025, the validator no longer produces warnings. Remove warnings from the CLI output. Remove references to warnings in the command help text and README.