### PR TITLE
Show timestamp and validator core version in output

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,8 @@ import { ValidationResult } from "hpt-validator/src/types"
 
 type FileFormat = "csv" | "json"
 
+const VALIDATOR_VERSION = "1.9.3"
+
 export async function validate(
   filepath: string,
   version: string,
@@ -32,6 +34,8 @@ export async function validate(
         .setEncoding("utf-8")
     : fs.createReadStream(filepath, "utf-8")
 
+  console.log(`Validating file: ${path.resolve(filepath)}`)
+  console.log(`Using hpt-validator version ${VALIDATOR_VERSION}`)
   console.log(`Validator run started at ${new Date().toString()}`)
   const validationResult = await validateFile(
     inputStream,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,6 +32,7 @@ export async function validate(
         .setEncoding("utf-8")
     : fs.createReadStream(filepath, "utf-8")
 
+  console.log(`Validator run started at ${new Date().toString()}`)
   const validationResult = await validateFile(
     inputStream,
     version,
@@ -43,6 +44,7 @@ export async function validate(
   inputStream.close()
   if (!validationResult) return
 
+  console.log(`Validator run completed at ${new Date().toString()}`)
   const errors = validationResult.errors
 
   if (errors.length > 0) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,7 +12,7 @@ import { ValidationResult } from "hpt-validator/src/types"
 
 type FileFormat = "csv" | "json"
 
-const VALIDATOR_VERSION = "1.9.3"
+const VALIDATOR_VERSION = "1.10.0"
 
 export async function validate(
   filepath: string,


### PR DESCRIPTION
## Show timestamp and validator core version in output

## Problem

Output from the validator does not currently include information about when the validator was run or the version being used. These values can be useful in recordkeeping and troubleshooting.

## Solution

Add output for start time, end time, and version of `hpt-validator` used. The start and end time are based on the system time.

## Test Plan
Run updated CLI and confirm that the start and end time reflect system time and that the current version of `hpt-validator` is indicated. At time of writing, this version should be `1.10.0`.
