### PR TITLE
Add alerts to output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
-        "hpt-validator": "^1.10.0"
+        "hpt-validator": "^1.11.0"
       },
       "bin": {
         "cms-hpt-validator": "dist/index.js"
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.10.0.tgz",
-      "integrity": "sha512-qq9EuhV8T0z4/PvXZgpQy+rFwGM7QfDsBd2imKj+wn8yw31z/pF9DguGItD73cotMfSDwKO1a6CETLBYtZjMFw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.11.0.tgz",
+      "integrity": "sha512-fdDw8qF1ZTjLjqeLnFKw3SYq3nnRqa6pUi4/Gvb6TeKRCreFVaVO/TDaxrwlNYUqteBNq+adLseQAUG1+5O/xg==",
       "license": "CC0-1.0",
       "dependencies": {
         "@streamparser/json": "^0.0.21",
@@ -2846,9 +2846,9 @@
       "dev": true
     },
     "hpt-validator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.10.0.tgz",
-      "integrity": "sha512-qq9EuhV8T0z4/PvXZgpQy+rFwGM7QfDsBd2imKj+wn8yw31z/pF9DguGItD73cotMfSDwKO1a6CETLBYtZjMFw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.11.0.tgz",
+      "integrity": "sha512-fdDw8qF1ZTjLjqeLnFKw3SYq3nnRqa6pUi4/Gvb6TeKRCreFVaVO/TDaxrwlNYUqteBNq+adLseQAUG1+5O/xg==",
       "requires": {
         "@streamparser/json": "^0.0.21",
         "@types/node": "^20.16.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hpt-validator": "^1.10.0"
+    "hpt-validator": "^1.11.0"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin-js": "^2.9.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,6 +50,7 @@ export async function validate(
 
   console.log(`Validator run completed at ${new Date().toString()}`)
   const errors = validationResult.errors
+  const alerts = validationResult.alerts
 
   if (errors.length > 0) {
     console.log(
@@ -60,6 +61,14 @@ export async function validate(
     console.table(errors)
   } else {
     console.log(chalk.green("No errors found"))
+  }
+  if (alerts) {
+    console.log(
+      chalk.yellow(
+        `${alerts.length === 1 ? "1 alert" : `${alerts.length} alerts`} found`
+      )
+    )
+    console.table(alerts)
   }
 }
 


### PR DESCRIPTION
v1.11.0 of `hpt-validator` adds alerts to the validation result. Show a message if there are no alerts. If there is at least one alert, show a table containing the alerts.