### PR TITLE
Update hpt-validator package with namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.7.1",
       "license": "CC0-1.0",
       "dependencies": {
+        "@cmsgov/hpt-validator": "^1.11.1",
         "chalk": "^5.3.0",
-        "commander": "^12.1.0",
-        "hpt-validator": "^1.11.1"
+        "commander": "^12.1.0"
       },
       "bin": {
         "cms-hpt-validator": "dist/index.js"
@@ -28,6 +28,57 @@
         "ts-node": "^10.9.1",
         "typescript": "^5.6.3"
       }
+    },
+    "node_modules/@cmsgov/hpt-validator": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@cmsgov/hpt-validator/-/hpt-validator-1.11.1.tgz",
+      "integrity": "sha512-Vtznhty5KSzUsuGu1o7DXwrKoc39ekxf4XeBiALQoZxTXG1QVZ+E022VWAdeH/zRM675cr6wgKoRqfe3I1yDzA==",
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@streamparser/json": "^0.0.21",
+        "@types/node": "^20.16.5",
+        "@types/papaparse": "^5.3.14",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "papaparse": "^5.4.1"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/@types/node": {
+      "version": "20.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
+      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1269,56 +1320,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/hpt-validator": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.11.1.tgz",
-      "integrity": "sha512-fVluFcruAs+OC0ZkXTxez2b8xnwU0kIAQbkOBsazbaawqgV//xm8/MxjuSSLZtvxOUnWPEM9RplcqJRQZ5gKtw==",
-      "dependencies": {
-        "@streamparser/json": "^0.0.21",
-        "@types/node": "^20.16.5",
-        "@types/papaparse": "^5.3.14",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "papaparse": "^5.4.1"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/@types/node": {
-      "version": "20.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.1.tgz",
-      "integrity": "sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/hpt-validator/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -1972,6 +1973,50 @@
     }
   },
   "dependencies": {
+    "@cmsgov/hpt-validator": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@cmsgov/hpt-validator/-/hpt-validator-1.11.1.tgz",
+      "integrity": "sha512-Vtznhty5KSzUsuGu1o7DXwrKoc39ekxf4XeBiALQoZxTXG1QVZ+E022VWAdeH/zRM675cr6wgKoRqfe3I1yDzA==",
+      "requires": {
+        "@streamparser/json": "^0.0.21",
+        "@types/node": "^20.16.5",
+        "@types/papaparse": "^5.3.14",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "papaparse": "^5.4.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "20.19.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
+          "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
+          "requires": {
+            "undici-types": "~6.21.0"
+          }
+        },
+        "ajv": {
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "undici-types": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+          "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+        }
+      }
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2843,50 +2888,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "hpt-validator": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.11.1.tgz",
-      "integrity": "sha512-fVluFcruAs+OC0ZkXTxez2b8xnwU0kIAQbkOBsazbaawqgV//xm8/MxjuSSLZtvxOUnWPEM9RplcqJRQZ5gKtw==",
-      "requires": {
-        "@streamparser/json": "^0.0.21",
-        "@types/node": "^20.16.5",
-        "@types/papaparse": "^5.3.14",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "papaparse": "^5.4.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "20.17.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.1.tgz",
-          "integrity": "sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==",
-          "requires": {
-            "undici-types": "~6.19.2"
-          }
-        },
-        "ajv": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        },
-        "undici-types": {
-          "version": "6.19.8",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-          "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-        }
-      }
     },
     "ignore": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
-    "hpt-validator": "^1.11.1"
+    "@cmsgov/hpt-validator": "^1.11.1"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin-js": "^2.9.0",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,8 +7,8 @@ import {
   JsonValidatorOptions,
   validateCsv,
   validateJson,
-} from "hpt-validator"
-import { ValidationResult } from "hpt-validator/src/types"
+} from "@cmsgov/hpt-validator"
+import { ValidationResult } from "@cmsgov/hpt-validator/src/types"
 
 type FileFormat = "csv" | "json"
 


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Update validator package to use namespaced `@cmsgov/hpt-validator`

## Problem

Now that the package has been deprecated under the old name, we need to use the namespaced package
