### PR TITLE
Add version output command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Arguments:
   version                    (choices: "v2.0", "v2.0.0")
 
 Options:
+  -V, --version              output the CLI version number
   -f, --format <string>      file format of file (choices: "csv", "json")
   -e, --error-limit <value>  maximum number for errors (default: 1000)
   -h, --help                 display help for command

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Argument, Option, InvalidArgumentError, Command } from "commander"
 import { validate } from "./commands.js"
+import { getVersionInfo } from "./version.js"
 
 main().catch((error) => {
   console.error(error)
@@ -11,6 +12,7 @@ async function main() {
   const program = new Command().name("cms-hpt-validator").showHelpAfterError()
 
   program
+    .version(getVersionInfo(), undefined, "output the CLI version number")
     .argument("<filepath>", "filepath to validate")
     .addArgument(new Argument("<version>").choices(["v2.0", "v2.0.0"]))
     .addOption(

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,52 @@
+import path from "path"
+import fs from "fs"
+import { EOL } from "os"
+import { execSync } from "child_process"
+import { fileURLToPath } from "node:url"
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+export function getVersionInfo(): string {
+  const installedVersion = getCLIVersion()
+  const latestVersion = getLatestPublishedVersion()
+  return [
+    `Current CLI version: ${installedVersion ?? "unknown"}`,
+    `Latest CLI version: ${latestVersion ?? "unknown"}`,
+  ].join(EOL)
+}
+
+export function getCLIVersion(): string {
+  const CLIVersion = getLocalVersion()
+  if (CLIVersion !== null) {
+    return `HPT Validator CLI version ${CLIVersion}`
+  }
+  return "unknown"
+}
+
+function getLocalVersion(): string | undefined {
+  const packageJSONPath = path.join(__dirname, "..", "package.json")
+  if (fs.existsSync(packageJSONPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(packageJSONPath, "utf-8"))?.version
+    } catch {
+      return
+    }
+  }
+  return
+}
+
+export function getLatestPublishedVersion(): string | undefined {
+  let latestVersion: string | undefined = undefined
+  const versionCheckCommand = "npm view hpt-validator-cli version"
+  try {
+    const execResult = execSync(versionCheckCommand)
+      ?.toString()
+      ?.replace(/\s*$/, "")
+    if (execResult.match(/^[0-9\.]*$/)) {
+      latestVersion = execResult
+    }
+  } catch (e) {
+    console.error(e)
+  }
+  return latestVersion
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,20 +7,14 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export function getVersionInfo(): string {
-  const installedVersion = getCLIVersion()
+  const installedVersion = getLocalVersion()
   const latestVersion = getLatestPublishedVersion()
+  const validatorVersion = getValidatorVersion()
   return [
     `Current CLI version: ${installedVersion ?? "unknown"}`,
     `Latest CLI version: ${latestVersion ?? "unknown"}`,
+    `Using hpt-validator version: ${validatorVersion ?? "unknown"}`,
   ].join(EOL)
-}
-
-export function getCLIVersion(): string {
-  const CLIVersion = getLocalVersion()
-  if (CLIVersion !== null) {
-    return `HPT Validator CLI version ${CLIVersion}`
-  }
-  return "unknown"
 }
 
 function getLocalVersion(): string | undefined {
@@ -35,13 +29,31 @@ function getLocalVersion(): string | undefined {
   return
 }
 
-export function getLatestPublishedVersion(): string | undefined {
+function getValidatorVersion(): string | undefined {
+  const packageJSONPath = path.join(
+    __dirname,
+    "..",
+    "node_modules",
+    "hpt-validator",
+    "package.json"
+  )
+  if (fs.existsSync(packageJSONPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(packageJSONPath, "utf-8"))?.version
+    } catch {
+      return
+    }
+  }
+  return
+}
+
+function getLatestPublishedVersion(): string | undefined {
   let latestVersion: string | undefined = undefined
   const versionCheckCommand = "npm view hpt-validator-cli version"
   try {
     const execResult = execSync(versionCheckCommand)
-      ?.toString()
-      ?.replace(/\s*$/, "")
+      .toString()
+      .replace(/\s*$/, "")
     if (execResult.match(/^[0-9\.]*$/)) {
       latestVersion = execResult
     }


### PR DESCRIPTION
This outputs the currently installed version of the CLI, the latest version of the CLI on NPM, and the version of `hpt-validator` being used by the CLI.